### PR TITLE
Fix dogfooding scan: install settings.xml and Maven toolchains

### DIFF
--- a/.github/workflows/shadow-scans.yml
+++ b/.github/workflows/shadow-scans.yml
@@ -17,6 +17,9 @@ jobs:
       - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
         with:
           version: 2025.9.12
+      - name: Setup Maven Toolchains
+        shell: bash
+        run: .github/scripts/setup-maven-toolchains.sh
       - uses: SonarSource/ci-github-actions/get-build-number@v1
       - uses: SonarSource/ci-github-actions/config-maven@master # Dogfood
         env:
@@ -25,6 +28,8 @@ jobs:
         with:
           common-mvn-flags: -Declipse.p2.mirrors=false -Dmaven.test.skip=true -Dcyclonedx.skip=false
           artifactory-reader-role: private-reader
+      - name: Setup settings.xml
+        run: .github/scripts/setup-settings-xml.sh
       - name: Custom versioning
         run: .github/scripts/set_maven_build_version.sh
       - name: Vault


### PR DESCRIPTION
The Unified Dogfooding scans workflow ran Tycho with no Eclipse p2 repository configured, so org.eclipse.swt (and the rest of the Eclipse platform) could not be resolved.

Commit bd43e4fe moved the p2 repo declaration from pom.xml into .github/scripts/settings.xml, installed by a 'Setup settings.xml' step, but only added that step to build.yml. Mirror the working build job by adding the same step here, plus 'Setup Maven Toolchains' for the JavaSE-17 execution environment the bundles require.